### PR TITLE
Fix such that new header formatting works correctly

### DIFF
--- a/Pluralchum.plugin.js
+++ b/Pluralchum.plugin.js
@@ -218,8 +218,11 @@ module.exports = class Pluralchum {
 						// So, we iterate over message elements that have their own props field, and add the color, item by item.
 						// But also plain text in a message *doesn't* have props, so we still have to set ret.props.style for that.
 						// Waugh.
+						// Making a list of the specific markup types that don't format correctly,
+						// Because if we just do this to all formatting, that overrides the URL color too.
+						const MarkupTypes = ["h1", "h2", "h3"];
 						for (const Element of MessageElements) {
-							if (Element.props) {
+							if (MarkupTypes.includes(Element.type)) {
 								Element.props.style = {
 									color: member.color
 								};

--- a/Pluralchum.plugin.js
+++ b/Pluralchum.plugin.js
@@ -210,9 +210,25 @@ module.exports = class Pluralchum {
 				// Set message text colour
 				if (member.color) {
 					let textContrast = this.contrast(this.hexToRgb(member.color), this.hexToRgb(this.contrastTestColour));
-					if (!this.doContrastTest || textContrast >= this.contrastThreshold)
-						ret.props.style = { color: member.color };
-
+					if (!this.doContrastTest || textContrast >= this.contrastThreshold) {
+						const MessageElements = ret.props.children[0];
+						// se: Each formatted element gets a separate entry in the array ret.props.children[0].
+						// Some of the new elements (specifically headers) have a .markup-XXXXXX h<x> class defined.
+						// These classes have a set color, and this overrides the element style on the top level message content element.
+						// So, we iterate over message elements that have their own props field, and add the color, item by item.
+						// But also plain text in a message *doesn't* have props, so we still have to set ret.props.style for that.
+						// Waugh.
+						for (const Element of MessageElements) {
+							if (Element.props) {
+								Element.props.style = {
+									color: member.color
+								};
+							}
+						}
+						ret.props.style = {
+							color: member.color
+						};
+					}
 				}
 
 			}.bind(this));}


### PR DESCRIPTION
se: With the new discord formatting updates, the .markup-XXXXXX class that is applied to messages has specific extensions for the new h1/h2/h3 formatting, and this was enough to override the text color just being applied to the parent div. 

As such, we made a small change so that per-element styling is applied to the troublesome child elements within the div, in addition to the div itself as was the prior behavior. This should keep all regular text coloring correctly, without overzealously also coloring things, such as link text. 

Thanks discord for making an extremely functional website, I can't wait to find out what happens when discriminators stop being real and the #0000 tag check for pk messages may or may not become... odd !