### PR TITLE
Don't discriminate with discriminators

### DIFF
--- a/src/edit.js
+++ b/src/edit.js
@@ -34,7 +34,7 @@ function patchEditAction(pluginName) {
     'editMessage',
     BdApi.Utils.debounce(function (ctx, [channel_id, message_id, message], original) {
       console.log("call")
-      if (MessageStore.getMessage(channel_id, message_id).author.discriminator === '0000') {
+      if (isProxiedMessage(MessageStore.getMessage(channel_id, message_id))) {
         let { content } = message;
         let channel = ChannelStore.getChannel(channel_id);
         let guild_id = channel.guild_id;

--- a/src/utility.js
+++ b/src/utility.js
@@ -77,7 +77,7 @@ class MapCell {
 }
 
 function isProxiedMessage(message) {
-  return message.author.discriminator === '0000';
+  return message.webhook_id !== null;
 }
 
 module.exports = {


### PR DESCRIPTION
Checking for the existence of a `webhook_id` is more precise and Discord is no doubt removing discriminators from the client API entirely soon.