### PR TITLE
Color EULA text according to active theme

### DIFF
--- a/src/eula.js
+++ b/src/eula.js
@@ -3,7 +3,7 @@ const React = BdApi.React;
 function headsUp(onConfirm, onCancel) {
   BdApi.UI.showConfirmationModal(
     'Heads up!',
-    <div style={{ color: '#eeeeee', 'text-align': 'center' }}>
+    <div style={{ color: 'var(--text-normal)', 'text-align': 'center' }}>
       This plugin uses the PluralKit API to fetch system and member data. <br />
       <br />
       Because of technical limitations, this data is cached on your computer between sessions. None of this data is ever


### PR DESCRIPTION
Fixes #30. Uses the `--text-normal` CSS variable set by Discord for the color of the EULA/first-launch message text. In light theme, this is readable, which it wasn't before. In dark theme, this is a slightly different color (computes to `#dcdee0`) than the previously-hardcoded `#eeeeee`, but I don't think it's a huge difference.

![image](https://github.com/estroBiologist/pluralchum/assets/4165301/6a8cf7a1-6cf9-44aa-8cbe-87d4865838f7)
![image](https://github.com/estroBiologist/pluralchum/assets/4165301/99f27f64-c17c-4baf-b6c8-e405e06d213a)
