### PR TITLE
Fix: badge styling & bump version to 2.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluralchum",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "repository": "https://github.com/estroBiologist/pluralchum.git",
   "author": "Ash Taylor",
   "license": "MIT",

--- a/src/components/PKBadge.js
+++ b/src/components/PKBadge.js
@@ -29,7 +29,7 @@ export default function PKBadge({ profileMap, userHash, profile }) {
 
   return (
     <span className='botTagCozy_c19a55 botTag_c19a55 botTagRegular__82f07 botTag__82f07 rem__82f07'>
-      <div className='botText_a9e77f'>
+      <div className='botText__82f07'>
         <a style={linkStyle} onClick={onClick}>
           {content}
         </a>

--- a/src/components/PKBadge.js
+++ b/src/components/PKBadge.js
@@ -28,7 +28,7 @@ export default function PKBadge({ profileMap, userHash, profile }) {
   }
 
   return (
-    <span className='botTagCozy_f9f2ca botTag_f9f2ca botTagRegular_a9e77f botTag_a9e77f rem_a9e77f'>
+    <span className='botTagCozy_c19a55 botTag_c19a55 botTagRegular__82f07 botTag__82f07 rem__82f07'>
       <div className='botText_a9e77f'>
         <a style={linkStyle} onClick={onClick}>
           {content}

--- a/src/header.js
+++ b/src/header.js
@@ -1,6 +1,6 @@
 /**
  * @name Pluralchum
- * @version 2.2.3
+ * @version 2.2.4
  * @description PluralKit integration for BetterDiscord. Inexplicably Homestuck-themed.
  * @author Ash Taylor
  *

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ import { settingsPanel } from './settingsPanel.js';
 import { ValueCell, pluginName } from './utility.js';
 import { checkForUpdates, upgradeCache } from './update.js';
 
-const version = '2.2.3';
+const version = '2.2.4';
 
 export class Pluralchum {
   patches = [];


### PR DESCRIPTION
Fixes PK badge styling to work on the latest version of discord. Again... the grind never ends. Also bumps the version to 2.2.4