### PR TITLE
temp fixes for deleted profiles and anim banners

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -19,6 +19,7 @@ function defaultSettings() {
     tagColourPref: ColourPreference.System,
     useServerNames: true,
     version: null,
+    doDisableBanners: false,
   };
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -33,7 +33,7 @@ export class Pluralchum {
     patchMessage(this.profileMap, this.enabled);
     this.patches.push(patchEditMenuItem());
     patchEditAction();
-    patchBotPopout(this.profileMap);
+    patchBotPopout(this.settings, this.profileMap);
 
     checkForUpdates(version);
   }

--- a/src/popout.js
+++ b/src/popout.js
@@ -3,7 +3,10 @@ const React = BdApi.React;
 import { pluginName } from './utility.js';
 
 const [BotPopout, viewBotPopout] = BdApi.Webpack.getWithKey(
-  BdApi.Webpack.Filters.byStrings('UserProfilePopoutWrapper:'),
+  BdApi.Webpack.Filters.combine(
+    BdApi.Webpack.Filters.byStrings("isNonUserBot", "bot", "onHide"), 
+    BdApi.Webpack.Filters.byRegex("^((?!UserProfilePanelRenderer).)*$")
+  )
 );
 
 const [Avatar, avatar] = BdApi.Webpack.getWithKey(

--- a/src/popout.js
+++ b/src/popout.js
@@ -35,7 +35,7 @@ function isValidHttpUrl(string) {
   return url.protocol === 'http:' || url.protocol === 'https:';
 }
 
-export function patchBotPopout(profileMap) {
+export function patchBotPopout(settings, profileMap) {
   BdApi.Patcher.instead(pluginName, UserProfileStore, 'getGuildMemberProfile', function (ctx, [userId, guildId], f) {
     if (userId && typeof userId !== 'string' && userId.userProfile) {
       return userId.userProfile;
@@ -70,7 +70,12 @@ export function patchBotPopout(profileMap) {
 
   BdApi.Patcher.after(pluginName, Banner, banner, function (_, [{ displayProfile }], ret) {
     if (displayProfile && isValidHttpUrl(displayProfile.banner)) {
-      ret.bannerSrc = displayProfile.banner;
+      if(settings.get()?.doDisableBanners) {
+        ret.bannerSrc = undefined;
+        ret.status = 'COMPLETE';
+      }else {
+        ret.bannerSrc = displayProfile.banner;
+      }
     }
     return ret;
   });

--- a/src/popout.js
+++ b/src/popout.js
@@ -2,12 +2,11 @@ const React = BdApi.React;
 
 import { pluginName } from './utility.js';
 
-const [BotPopout, viewBotPopout] = BdApi.Webpack.getWithKey(
-  BdApi.Webpack.Filters.combine(
-    BdApi.Webpack.Filters.byStrings("isNonUserBot", "bot", "onHide"), 
-    BdApi.Webpack.Filters.byRegex("^((?!UserProfilePanelRenderer).)*$")
-  )
+const [WebhookPopout, viewWebhookPopout] = BdApi.Webpack.getWithKey(
+  BdApi.Webpack.Filters.byStrings('messageId', 'user', 'openUserProfileModal', 'setPopoutRef', 'isClyde'),
 );
+
+const viewBotPopout = BdApi.Webpack.getByStrings('messageId', 'user', 'openUserProfileModal', 'setPopoutRef', 'BotUserProfilePopout');
 
 const [Avatar, avatar] = BdApi.Webpack.getWithKey(
   BdApi.Webpack.Filters.byStrings('avatarSrc', 'avatarDecorationSrc', 'eventHandlers', 'avatarOverride'),
@@ -83,7 +82,7 @@ export function patchBotPopout(settings, profileMap) {
     return ret;
   });
 
-  BdApi.Patcher.instead(pluginName, BotPopout, viewBotPopout, function (_, [args], f) {
+  BdApi.Patcher.instead(pluginName, WebhookPopout, viewWebhookPopout, function (_, [args], f) {
     let message = MessageStore.getMessage(args.channelId, args.messageId);
 
     if (!message) {
@@ -131,7 +130,11 @@ export function patchBotPopout(settings, profileMap) {
       user.avatar = 'https://cdn.discordapp.com/embed/avatars/0.png';
     }
 
-    return f({ ...args, user });
+    if(viewBotPopout) return viewBotPopout({ ...args, user });
+    else {
+      console.error('[PLURALCHUM] Error, bot popout function is undefined! Falling back to webhook function...');
+      return f({ ...args, user });
+    }
   });
 
   BdApi.Patcher.after(pluginName, UsernameRow, usernameRow, function (ctx, [args], ret) {

--- a/src/profiles.js
+++ b/src/profiles.js
@@ -60,6 +60,7 @@ async function pkResponseToProfile(response) {
     console.log('RESPONSE');
     let data = await response.json();
     console.log(data);
+    if(data.system == null && data.member == null) return { status: ProfileStatus.NotPK };
     return pkDataToProfile(data);
   } else if (response.status == 404) {
     return { status: ProfileStatus.NotPK };

--- a/src/settingsPanel.js
+++ b/src/settingsPanel.js
@@ -94,6 +94,16 @@ function preferencesPanel(settings) {
   };
 }
 
+function doDisableBanners(settings) {
+  return {
+    type: 'switch',
+    id: 'doDisableBanners',
+    name: 'Disable banners',
+    note: "",
+    value: settings.get().doDisableBanners,
+  };
+}
+
 function doContrastTest(settings) {
   return {
     type: 'switch',
@@ -134,7 +144,7 @@ function accessibilityPanel(settings) {
     name: 'Accessibility',
     collapsible: true,
     shown: false,
-    settings: [doContrastTest(settings), contrastTestColour(settings), contrastThreshold(settings)],
+    settings: [doDisableBanners(settings), doContrastTest(settings), contrastTestColour(settings), contrastThreshold(settings)],
   };
 }
 


### PR DESCRIPTION
potential temporary fixes for [#71](https://github.com/estroBiologist/pluralchum/issues/71) and [#72](https://github.com/estroBiologist/pluralchum/issues/72).

- adds a toggle for disabling banners in the accessibility settings
- if a profile is deleted (system==null && member==null), sets the status to 'NOT_PK'