### PR TITLE
fix: get most things working again

### DIFF
--- a/src/messages.js
+++ b/src/messages.js
@@ -1,11 +1,3 @@
-const MessageContent = BdApi.Webpack.getModule(m => {
-  let s = m?.type?.toString();
-  return s && s.includes('SENDING') && s.includes('SEND_FAILED');
-});
-const [MessageHeader, messageHeader] = BdApi.Webpack.getWithKey(
-  BdApi.Webpack.Filters.byStrings('includeConvenienceGlow', 'shouldUnderlineOnHover'),
-);
-const [Message, message] = BdApi.Webpack.getWithKey(BdApi.Webpack.Filters.byStrings('zalgo', 'childrenRepliedMessage'));
 const React = BdApi.React;
 
 import { MapCell, pluginName } from './utility.js';
@@ -14,7 +6,11 @@ import MessageHeaderProxy from './components/MessageHeaderProxy.js';
 import MessageProxy from './components/MessageProxy.js';
 
 export function patchMessageContent(settings, profileMap, enabled) {
-  BdApi.Patcher.instead(pluginName, MessageContent, 'type', function (ctx, [props], f) {
+  BdApi.Webpack.waitForModule(m => {
+    let s = m?.type?.toString();
+    return s && s.includes('SENDING') && s.includes('SEND_FAILED');
+  }).then(function (MessageContent) {
+    BdApi.Patcher.instead(pluginName, MessageContent, 'type', function (ctx, [props], f) {
     return (
       <MessageContentProxy
         settingsCell={settings}
@@ -25,32 +21,42 @@ export function patchMessageContent(settings, profileMap, enabled) {
       />
     );
   });
+})
 }
 
 export function patchMessageHeader(settings, profileMap, enabled) {
-  BdApi.Patcher.instead(pluginName, MessageHeader, messageHeader, function (ctx, [props], f) {
-    if (!props) {
-      return;
-    }
+  BdApi.Webpack.waitForModule(BdApi.Webpack.Filters.byStrings('includeConvenienceGlow', 'shouldUnderlineOnHover'), {
+    defaultExport: false
+  }).then(function (MessageHeader) {
+    BdApi.Patcher.instead(pluginName, MessageHeader, 'A', function (ctx, [props], f) {
+      if (!props) {
+        return;
+      }
 
-    return (
-      <MessageHeaderProxy
-        settingsCell={settings}
-        profileMap={profileMap}
-        enabledCell={enabled}
-        messageHeader={f(props)}
-        message={props.message}
-        guildId={props.channel.guild_id}
-        onClickUsername={props.onClick}
-      />
-    );
-  });
+      return (
+        <MessageHeaderProxy
+          settingsCell={settings}
+          profileMap={profileMap}
+          enabledCell={enabled}
+          messageHeader={f(props)}
+          message={props.message}
+          guildId={props.channel.guild_id}
+          onClickUsername={props.onClick}
+        />
+      ); BdApi.Webpack.waitForModule(BdApi.Webpack.Filters.byStrings('zalgo', 'childrenRepliedMessage'), {
+    defaultExport: false
+  })
+    });
+  })
 }
 
 export function patchMessage(profileMap, enabled) {
   let unblockedMap = new MapCell({});
 
-  BdApi.Patcher.instead(pluginName, Message, message, function (ctx, [props], f) {
+  BdApi.Webpack.waitForModule(BdApi.Webpack.Filters.byStrings('zalgo', 'childrenRepliedMessage'), {
+    defaultExport: false
+  }).then(function (Message) {
+    BdApi.Patcher.instead(pluginName, Message, 'A', function (ctx, [props], f) {
     return (
       <MessageProxy
         profileMap={profileMap}
@@ -62,4 +68,4 @@ export function patchMessage(profileMap, enabled) {
       />
     );
   });
-}
+})}

--- a/src/popout.js
+++ b/src/popout.js
@@ -70,18 +70,19 @@ export function patchBotPopout(settings, profileMap) {
     }
   });
 
-  const [Avatar, avatar] = BdApi.Webpack.getWithKey(
-    BdApi.Webpack.Filters.byStrings('avatarSrc', 'avatarDecorationSrc', 'eventHandlers', 'avatarOverride'),
-  );
-
-  BdApi.Patcher.after(pluginName, Avatar, avatar, function (_, [args], ret) {
-    let user = args?.userId?.user;
-    if (user) {
-      ret.avatarSrc = user.avatar;
-      ret.avatarPlaceholder = user.avatar;
-    }
-    return ret;
-  });
+  BdApi.Webpack.waitForModule(
+    BdApi.Webpack.Filters.byStrings('avatarSrc', 'avatarDecorationSrc', 'eventHandlers', 'avatarOverride'), 
+    { defaultExport: false }
+  ).then(function (Avatars) {
+    BdApi.Patcher.after(pluginName, Avatars, 'A', function (_, [args], ret) {
+      let user = args?.userId?.user;
+      if (user) {
+        ret.avatarSrc = user.avatar;
+        ret.avatarPlaceholder = user.avatar;
+      }
+      return ret;
+    });
+  });  
 
   const [Banner, banner] = BdApi.Webpack.getWithKey(BdApi.Webpack.Filters.byStrings('displayProfile', 'SHOULD_LOAD'));
 

--- a/src/popout.js
+++ b/src/popout.js
@@ -1,41 +1,6 @@
 const React = BdApi.React;
 
 import { pluginName } from './utility.js';
-
-const [WebhookPopout, viewWebhookPopout] = BdApi.Webpack.getWithKey(
-  BdApi.Webpack.Filters.combine(
-    BdApi.Webpack.Filters.byStrings('messageId', 'user', 'openUserProfileModal', 'setPopoutRef'),
-    BdApi.Webpack.Filters.byRegex('^((?!getGuild).)*$'),
-  ),
-);
-
-const [BotPopout, viewBotPopout] = BdApi.Webpack.getWithKey(
-  BdApi.Webpack.Filters.combine(
-    BdApi.Webpack.Filters.byStrings('messageId', 'user', 'openUserProfileModal', 'setPopoutRef', 'currentUser'),
-    BdApi.Webpack.Filters.byRegex('^((?!customStatusPrompt).)*$'),
-  ),
-);
-
-const [Avatar, avatar] = BdApi.Webpack.getWithKey(
-  BdApi.Webpack.Filters.byStrings('avatarSrc', 'avatarDecorationSrc', 'eventHandlers', 'avatarOverride'),
-);
-
-const [Banner, banner] = BdApi.Webpack.getWithKey(BdApi.Webpack.Filters.byStrings('displayProfile', 'SHOULD_LOAD'));
-
-const [UsernameRow, usernameRow] = BdApi.Webpack.getWithKey(
-  BdApi.Webpack.Filters.byStrings('pendingDisplayNameStyles', 'isVerifiedBot'),
-);
-
-const [Role, role] = BdApi.Webpack.getWithKey(BdApi.Webpack.Filters.byStrings('allowEditing', 'overflowCount'));
-
-const UserProfileStore = BdApi.Webpack.getModule(BdApi.Webpack.Filters.byStoreName('UserProfileStore'));
-const UserStore = BdApi.Webpack.getModule(BdApi.Webpack.Filters.byStoreName('UserStore'));
-const GuildMemberStore = BdApi.Webpack.getModule(BdApi.Webpack.Filters.byStoreName('GuildMemberStore'));
-const GuildMemberRequesterStore = BdApi.Webpack.getModule(
-  BdApi.Webpack.Filters.byStoreName('GuildMemberRequesterStore'),
-);
-const User = BdApi.Webpack.getByPrototypeKeys('addGuildAvatarHash', 'isLocalBot');
-const MessageStore = BdApi.Webpack.getModule(BdApi.Webpack.Filters.byStoreName('MessageStore'));
 import { getUserHash, ProfileStatus } from './profiles.js';
 import PopoutPKBadge from './components/PopoutPKBadge.js';
 import PopoutBio from './components/PopoutBio.js';
@@ -53,6 +18,7 @@ function isValidHttpUrl(string) {
 }
 
 export function patchBotPopout(settings, profileMap) {
+  const UserProfileStore = BdApi.Webpack.getModule(BdApi.Webpack.Filters.byStoreName('UserProfileStore'));
   BdApi.Patcher.instead(pluginName, UserProfileStore, 'getGuildMemberProfile', function (ctx, [userId, guildId], f) {
     if (userId && typeof userId !== 'string' && userId.userProfile) {
       return userId.userProfile;
@@ -68,6 +34,11 @@ export function patchBotPopout(settings, profileMap) {
       return f(userId, guildId);
     }
   });
+
+  const GuildMemberStore = BdApi.Webpack.getModule(BdApi.Webpack.Filters.byStoreName('GuildMemberStore'));
+  const GuildMemberRequesterStore = BdApi.Webpack.getModule(
+    BdApi.Webpack.Filters.byStoreName('GuildMemberRequesterStore'),
+  );
 
   BdApi.Patcher.instead(pluginName, GuildMemberStore, 'getMember', function (ctx, [guildId, userId], f) {
     if (userId && typeof userId !== 'string' && userId.user) {
@@ -89,6 +60,8 @@ export function patchBotPopout(settings, profileMap) {
     }
   });
 
+  const UserStore = BdApi.Webpack.getModule(BdApi.Webpack.Filters.byStoreName('UserStore'));
+
   BdApi.Patcher.instead(pluginName, UserStore, 'getUser', function (ctx, [userId, guildId], f) {
     if (userId && typeof userId !== 'string' && userId.user) {
       return userId.user;
@@ -97,14 +70,20 @@ export function patchBotPopout(settings, profileMap) {
     }
   });
 
+  const [Avatar, avatar] = BdApi.Webpack.getWithKey(
+    BdApi.Webpack.Filters.byStrings('avatarSrc', 'avatarDecorationSrc', 'eventHandlers', 'avatarOverride'),
+  );
+
   BdApi.Patcher.after(pluginName, Avatar, avatar, function (_, [args], ret) {
     let user = args?.userId?.user;
-    if (user && isValidHttpUrl(user.avatar)) {
+    if (user) {
       ret.avatarSrc = user.avatar;
       ret.avatarPlaceholder = user.avatar;
     }
     return ret;
   });
+
+  const [Banner, banner] = BdApi.Webpack.getWithKey(BdApi.Webpack.Filters.byStrings('displayProfile', 'SHOULD_LOAD'));
 
   BdApi.Patcher.after(pluginName, Banner, banner, function (_, [{ displayProfile }], ret) {
     if (displayProfile && isValidHttpUrl(displayProfile.banner)) {
@@ -118,80 +97,101 @@ export function patchBotPopout(settings, profileMap) {
     return ret;
   });
 
-  BdApi.Patcher.instead(pluginName, WebhookPopout, viewWebhookPopout, function (_, [args], f) {
-    let message = MessageStore.getMessage(args.channelId, args.messageId);
+  BdApi.Webpack.waitForModule(BdApi.Webpack.Filters.combine(
+    BdApi.Webpack.Filters.byStrings('messageId', 'user', 'openUserProfileModal', 'setPopoutRef'),
+    BdApi.Webpack.Filters.byRegex('^((?!getGuild).)*$'),
+  ), { defaultExport: false }
+  ).then(function (WebhookPopout) {
+    BdApi.Patcher.instead(pluginName, WebhookPopout, 'default', function (_, [args], f) {
+      const MessageStore = BdApi.Webpack.getModule(BdApi.Webpack.Filters.byStoreName('MessageStore'));
+      let message = MessageStore.getMessage(args.channelId, args.messageId);
 
-    if (!message) {
-      return f(args);
-    }
-
-    let userHash = getUserHash(message);
-    let profile = profileMap.get(userHash);
-
-    if (!profile || profile?.status === ProfileStatus.NotPK) {
-      return f(args);
-    }
-
-    let userProfile = {
-      bio: profile.description ?? '',
-      system_bio: profile.system_description ?? '',
-      userId: args.user.id,
-      guildId: args.guildId,
-      pronouns: profile.pronouns,
-      sender: profile.sender,
-    };
-
-    if (profile.color) {
-      userProfile.accentColor = Number('0x' + profile.color.substring(1));
-    } else {
-      userProfile.accentColor = Number('0x5b63f4');
-    }
-
-    if (profile.banner) {
-      userProfile.banner = profile.banner;
-    }
-
-    let user = new User({
-      username: profile.system_name ?? profile.system,
-      globalName: profile.name,
-      bot: true,
-      discriminator: profile.system,
-    });
-
-    user.id = { userProfile, user, isPK: true };
-
-    if (args.user.avatar) {
-      user.avatar = 'https://cdn.discordapp.com/avatars/' + args.user.id + '/' + args.user.avatar + '.webp';
-    } else {
-      //fallback to default avatar
-      user.avatar = 'https://cdn.discordapp.com/embed/avatars/0.png';
-    }
-
-    if (BotPopout && viewBotPopout) return BotPopout[viewBotPopout]({ ...args, user });
-    else {
-      console.error('[PLURALCHUM] Error, bot popout function is undefined! Falling back to webhook function...');
-      return f({ ...args, user });
-    }
-  });
-
-  BdApi.Patcher.after(pluginName, UsernameRow, usernameRow, function (ctx, [args], ret) {
-    if (args.user?.id?.isPK) {
-      let name = ret.props.children[0].props.children[0];
-      if (Array.isArray(name.props.children)) {
-        name.props.children[2] = <PopoutPKBadge />;
-      } else {
-        name.props.children.props.children[2] = <PopoutPKBadge />;
+      if (!message) {
+        return f(args);
       }
-    }
 
-    return ret;
+      let userHash = getUserHash(message);
+      let profile = profileMap.get(userHash);
+
+      if (!profile || profile?.status === ProfileStatus.NotPK) {
+        return f(args);
+      }
+
+      let userProfile = {
+        bio: profile.description ?? '',
+        system_bio: profile.system_description ?? '',
+        userId: args.user.id,
+        guildId: args.guildId,
+        pronouns: profile.pronouns,
+        sender: profile.sender,
+      };
+
+      if (profile.color) {
+        userProfile.accentColor = Number('0x' + profile.color.substring(1));
+      } else {
+        userProfile.accentColor = Number('0x5b63f4');
+      }
+
+      if (profile.banner) {
+        userProfile.banner = profile.banner;
+      }
+
+      const User = BdApi.Webpack.getByPrototypeKeys('addGuildAvatarHash', 'isLocalBot');
+
+      let user = new User({
+        username: profile.system_name ?? profile.system,
+        globalName: profile.name,
+        bot: true,
+        discriminator: profile.system,
+      });
+
+      user.id = { userProfile, user, isPK: true };
+
+      if (args.user.avatar) {
+        user.avatar = 'https://cdn.discordapp.com/avatars/' + args.user.id + '/' + args.user.avatar + '.webp';
+      } else {
+        //fallback to default avatar
+        user.avatar = 'https://cdn.discordapp.com/embed/avatars/0.png';
+      }
+
+      const BotPopout = BdApi.Webpack.getModule(
+        BdApi.Webpack.Filters.combine(
+          BdApi.Webpack.Filters.byStrings('messageId', 'user', 'setPopoutRef', 'currentUser'),
+          BdApi.Webpack.Filters.byRegex('^((?!guild_id).)*$'),
+        ),
+      );
+
+      if (BotPopout) return BotPopout({ ...args, user });
+      else {
+        console.error('[PLURALCHUM] Error, bot popout function is undefined! Falling back to webhook function...');
+        return f({ ...args, user });
+      }
+    })
   });
 
-  BdApi.Patcher.before(pluginName, Role, role, function (ctx, args) {
-    if (args[0].userId?.isPK) {
-      args[0].allowEditing = false;
-    }
-  });
+  const [UsernameRow, usernameRow] = BdApi.Webpack.getWithKey(
+    BdApi.Webpack.Filters.byStrings('displayNameStyles', 'isVerifiedBot'),
+  );
+  // BdApi.Patcher.after(pluginName, UsernameRow, usernameRow, function (ctx, [args], ret) {
+  //   if (args.user?.id?.isPK) {
+  //     let name = ret.props.children[0].props.children[0];
+  //     if (Array.isArray(name.props.children)) {
+  //       name.props.children[2] = <PopoutPKBadge />;
+  //     } else {
+  //       name.props.children.props.children[2] = <PopoutPKBadge />;
+  //     }
+  //   }
+
+  //   return ret;
+  // });
+
+  const [Role, role] = BdApi.Webpack.getWithKey(BdApi.Webpack.Filters.byStrings('allowEditing', 'canAddRoles'));
+  if (Role)
+    BdApi.Patcher.before(pluginName, Role, role, function (ctx, args) {
+      if (args[0].userId?.isPK) {
+        args[0].allowEditing = false;
+      }
+    });
 
   BdApi.Webpack.waitForModule(BdApi.Webpack.Filters.byKeys('openUserProfileModal')).then(function (userProfile) {
     if (userProfile === undefined) {
@@ -199,6 +199,7 @@ export function patchBotPopout(settings, profileMap) {
       return;
     }
     const Dispatcher = BdApi.Webpack.Stores.UserStore._dispatcher;
+
     BdApi.Patcher.instead(pluginName, userProfile, 'openUserProfileModal', (ctx, [args], f) => {
       if (typeof args.userId !== 'string' && args.userId?.isPK) {
         Dispatcher.dispatch({
@@ -238,3 +239,4 @@ export function patchBotPopout(settings, profileMap) {
     return <PopoutBio content={args.bio} />;
   });
 }
+


### PR DESCRIPTION
hi, this is a pretty intensive change and not everything works yet. here's the rundown

- a lot of modules that pluralchum called on startup are now loaded dynamically. this means a lot had to be replaced with `BdApi.Webpack.waitForModule` instead
- this *also* means that we can't always patch the webhook popout with the bot one. currently the webhook popout will be used unless the user has clicked on the popout of a real bot before, which loads that module.
- I cannot seem to get avatars to work on popouts :( I have tried for a couple hours but ended up giving up
- I have not tested message editing, unsure if that works.

All in all, this is pretty flaky but I figured it'd be better to get *something* in so no one has to do the same work again.